### PR TITLE
fix: Always re-build UI in Dockerfile

### DIFF
--- a/docker/build_admin_ui.sh
+++ b/docker/build_admin_ui.sh
@@ -9,10 +9,10 @@ pwd
 
 
 # only run this step for litellm enterprise, we run this if enterprise/enterprise_ui/_enterprise.json exists
-if [ ! -f "enterprise/enterprise_ui/enterprise_colors.json" ]; then
-    echo "Admin UI - using default LiteLLM UI"
-    exit 0
-fi
+# if [ ! -f "enterprise/enterprise_ui/enterprise_colors.json" ]; then
+#     echo "Admin UI - using default LiteLLM UI"
+#     exit 0
+# fi
 
 echo "Building Custom Admin UI..."
 
@@ -47,7 +47,9 @@ nvm use v18.17.0
 npm install -g npm
 
 # copy _enterprise.json from this directory to /ui/litellm-dashboard, and rename it to ui_colors.json
-cp enterprise/enterprise_ui/enterprise_colors.json ui/litellm-dashboard/ui_colors.json
+if [ -f "enterprise/enterprise_ui/enterprise_colors.json" ]; then
+    cp enterprise/enterprise_ui/enterprise_colors.json ui/litellm-dashboard/ui_colors.json
+fi
 
 # cd in to /ui/litellm-dashboard
 cd ui/litellm-dashboard


### PR DESCRIPTION
In the Dockerfile, UI is only re-built and copied over to BE when this file `enterprise/enterprise_ui/_enterprise.json` exists.

The logic is modified so that UI is always re-built

Closes #9