### PR TITLE
Danielc/dashboard housekeeping

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -156,6 +156,7 @@ from litellm.proxy.auth.auth_checks import (
     ExperimentalUIJWTToken,
     get_team_object,
     log_db_metrics,
+    _is_user_proxy_admin,
 )
 from litellm.proxy.auth.auth_utils import check_response_size_is_safe
 from litellm.proxy.auth.handle_jwt import JWTHandler
@@ -3445,6 +3446,15 @@ async def model_list(
 
     This is just for compatibility with openai projects like aider.
     """
+    # Check if user is admin - only admins can view models
+    if not _is_user_proxy_admin(user_obj=user_api_key_dict.user_obj):
+        raise HTTPException(
+            status_code=403,
+            detail="Only proxy admin can view models. Your role={}".format(
+                user_api_key_dict.user_obj.user_role if user_api_key_dict.user_obj else "unknown"
+            )
+        )
+    
     global llm_model_list, general_settings, llm_router, prisma_client, user_api_key_cache, proxy_logging_obj
     all_models = []
     model_access_groups: Dict[str, List[str]] = defaultdict(list)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -156,7 +156,6 @@ from litellm.proxy.auth.auth_checks import (
     ExperimentalUIJWTToken,
     get_team_object,
     log_db_metrics,
-    _is_user_proxy_admin,
 )
 from litellm.proxy.auth.auth_utils import check_response_size_is_safe
 from litellm.proxy.auth.handle_jwt import JWTHandler
@@ -3446,15 +3445,6 @@ async def model_list(
 
     This is just for compatibility with openai projects like aider.
     """
-    # Check if user is admin - only admins can view models
-    if not _is_user_proxy_admin(user_obj=user_api_key_dict.user_obj):
-        raise HTTPException(
-            status_code=403,
-            detail="Only proxy admin can view models. Your role={}".format(
-                user_api_key_dict.user_obj.user_role if user_api_key_dict.user_obj else "unknown"
-            )
-        )
-    
     global llm_model_list, general_settings, llm_router, prisma_client, user_api_key_cache, proxy_logging_obj
     all_models = []
     model_access_groups: Dict[str, List[str]] = defaultdict(list)

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -4,6 +4,7 @@ import React, { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { jwtDecode } from "jwt-decode";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { all_admin_roles } from "@/utils/roles";
 import { defaultOrg } from "@/components/common_components/default_org";
 import { KeyResponse, Team } from "@/components/key_team_helpers/key_list";
 import Navbar from "@/components/navbar";
@@ -289,17 +290,24 @@ export default function CreateKeyPage() {
                   createClicked={createClicked}
                 />
               ) : page == "models" ? (
-                <ModelDashboard
-                  userID={userID}
-                  userRole={userRole}
-                  token={token}
-                  keys={keys}
-                  accessToken={accessToken}
-                  modelData={modelData}
-                  setModelData={setModelData}
-                  premiumUser={premiumUser}
-                  teams={teams}
-                />
+                all_admin_roles.includes(userRole) ? (
+                  <ModelDashboard
+                    userID={userID}
+                    userRole={userRole}
+                    token={token}
+                    keys={keys}
+                    accessToken={accessToken}
+                    modelData={modelData}
+                    setModelData={setModelData}
+                    premiumUser={premiumUser}
+                    teams={teams}
+                  />
+                ) : (
+                  <div style={{ padding: "20px", textAlign: "center" }}>
+                    <h2>Access Denied</h2>
+                    <p>You don't have permission to view the Models page. Admin privileges required.</p>
+                  </div>
+                )
               ) : page == "llm-playground" ? (
                 <ChatUI
                   userID={userID}

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -366,11 +366,25 @@ export default function CreateKeyPage() {
                   premiumUser={premiumUser}
                 />
               ) : page == "budgets" ? (
-                <BudgetPanel accessToken={accessToken} />
+                all_admin_roles.includes(userRole) ? (
+                  <BudgetPanel accessToken={accessToken} />
+                ) : (
+                  <div style={{ padding: "20px", textAlign: "center" }}>
+                    <h2>Access Denied</h2>
+                    <p>You don't have permission to view the Budgets page. Admin privileges required.</p>
+                  </div>
+                )
               ) : page == "guardrails" ? (
                 <GuardrailsPanel accessToken={accessToken} userRole={userRole} />
               ): page == "transform-request" ? (
-                <TransformRequestPanel accessToken={accessToken} />
+                all_admin_roles.includes(userRole) ? (
+                  <TransformRequestPanel accessToken={accessToken} />
+                ) : (
+                  <div style={{ padding: "20px", textAlign: "center" }}>
+                    <h2>Access Denied</h2>
+                    <p>You don't have permission to view the API Playground. Admin privileges required.</p>
+                  </div>
+                )
               ) : page == "general-settings" ? (
                 <GeneralSettings
                   userID={userID}
@@ -385,13 +399,20 @@ export default function CreateKeyPage() {
                   premiumUser={premiumUser}
                 />
               ) : page == "caching" ? (
-                <CacheDashboard
-                  userID={userID}
-                  userRole={userRole}
-                  token={token}
-                  accessToken={accessToken}
-                  premiumUser={premiumUser}
-                />
+                all_admin_roles.includes(userRole) ? (
+                  <CacheDashboard
+                    userID={userID}
+                    userRole={userRole}
+                    token={token}
+                    accessToken={accessToken}
+                    premiumUser={premiumUser}
+                  />
+                ) : (
+                  <div style={{ padding: "20px", textAlign: "center" }}>
+                    <h2>Access Denied</h2>
+                    <p>You don't have permission to view the Caching page. Admin privileges required.</p>
+                  </div>
+                )
               ) : page == "pass-through-settings" ? (
                 <PassThroughSettings
                   userID={userID}
@@ -408,23 +429,44 @@ export default function CreateKeyPage() {
                   allTeams={(teams as Team[]) ?? []}
                 />
               ) : page == "mcp-servers" ? (
-                <MCPServers
-                  accessToken={accessToken}
-                  userRole={userRole}
-                  userID={userID}
-                />
+                all_admin_roles.includes(userRole) ? (
+                  <MCPServers
+                    accessToken={accessToken}
+                    userRole={userRole}
+                    userID={userID}
+                  />
+                ) : (
+                  <div style={{ padding: "20px", textAlign: "center" }}>
+                    <h2>Access Denied</h2>
+                    <p>You don't have permission to view MCP Servers. Admin privileges required.</p>
+                  </div>
+                )
               ) : page == "tag-management" ? (
-                <TagManagement
-                  accessToken={accessToken}
-                  userRole={userRole}
-                  userID={userID}
-                />
+                all_admin_roles.includes(userRole) ? (
+                  <TagManagement
+                    accessToken={accessToken}
+                    userRole={userRole}
+                    userID={userID}
+                  />
+                ) : (
+                  <div style={{ padding: "20px", textAlign: "center" }}>
+                    <h2>Access Denied</h2>
+                    <p>You don't have permission to view Tag Management. Admin privileges required.</p>
+                  </div>
+                )
               ) : page == "vector-stores" ? (
-                <VectorStoreManagement
-                  accessToken={accessToken}
-                  userRole={userRole}
-                  userID={userID}
-                />
+                all_admin_roles.includes(userRole) ? (
+                  <VectorStoreManagement
+                    accessToken={accessToken}
+                    userRole={userRole}
+                    userID={userID}
+                  />
+                ) : (
+                  <div style={{ padding: "20px", textAlign: "center" }}>
+                    <h2>Access Denied</h2>
+                    <p>You don't have permission to view Vector Stores. Admin privileges required.</p>
+                  </div>
+                )
               ) : page == "new_usage" ? (
                 <NewUsagePage
                   userID={userID}

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -56,9 +56,9 @@ const Sidebar: React.FC<SidebarProps> = ({
   const menuItems: MenuItem[] = [
     { key: "1", page: "api-keys", label: "Virtual Keys", icon: <KeyOutlined /> },
     { key: "3", page: "llm-playground", label: "Test Key", icon: <PlayCircleOutlined />, roles: rolesWithWriteAccess },
-    { key: "2", page: "models", label: "Models", icon: <BlockOutlined />, roles: rolesWithWriteAccess },
+    { key: "2", page: "models", label: "Models", icon: <BlockOutlined />, roles: all_admin_roles },
     { key: "12", page: "new_usage", label: "Usage", icon: <BarChartOutlined />, roles: [...all_admin_roles, ...internalUserRoles] },
-    { key: "6", page: "teams", label: "Teams", icon: <TeamOutlined /> },
+    { key: "6", page: "teams", label: "Teams", icon: <TeamOutlined />, roles: all_admin_roles },
     { key: "17", page: "organizations", label: "Organizations", icon: <BankOutlined />, roles: all_admin_roles },
     { key: "5", page: "users", label: "Internal Users", icon: <UserOutlined />, roles: all_admin_roles },
     { key: "14", page: "api_ref", label: "API Reference", icon: <ApiOutlined /> },

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -70,10 +70,11 @@ const Sidebar: React.FC<SidebarProps> = ({
       page: "experimental",
       label: "Experimental", 
       icon: <ExperimentOutlined />,
+      roles: all_admin_roles,
       children: [
         { key: "9", page: "caching", label: "Caching", icon: <DatabaseOutlined />, roles: all_admin_roles },
         { key: "10", page: "budgets", label: "Budgets", icon: <BankOutlined />, roles: all_admin_roles },
-        { key: "20", page: "transform-request", label: "API Playground", icon: <ApiOutlined />, roles: [...all_admin_roles, ...internalUserRoles] },
+        { key: "20", page: "transform-request", label: "API Playground", icon: <ApiOutlined />, roles: all_admin_roles },
         { key: "18", page: "mcp-servers", label: "MCP Servers", icon: <ToolOutlined />, roles: all_admin_roles },
         { key: "19", page: "tag-management", label: "Tag Management", icon: <TagsOutlined />, roles: all_admin_roles },
         { key: "21", page: "vector-stores", label: "Vector Stores", icon: <DatabaseOutlined />, roles: all_admin_roles },

--- a/ui/litellm-dashboard/src/components/model_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard.tsx
@@ -1025,6 +1025,15 @@ const ModelDashboard: React.FC<ModelDashboardProps> = ({
     );
   }
 
+  // Check if user has admin access
+  if (!all_admin_roles.includes(userRole || "")) {
+    return (
+      <div style={{ padding: "20px", textAlign: "center" }}>
+        <Text>Access denied. Admin privileges required to view models.</Text>
+      </div>
+    );
+  }
+
   return (
     <div style={{ width: "100%", height: "100%" }}>
       {selectedModelId ? (


### PR DESCRIPTION
# Removal of elements from left nav bar on frontend 

![Screenshot 2025-06-12 at 5 29 20 PM](https://github.com/user-attachments/assets/be81cc31-7017-44d6-aef5-0790ec53f039)
- When navigating via page routing to `/page=budgets` for instance, non-admin users would get a `Access Denied
You don't have permission to view the Caching page. Admin privileges required.` error. (on localhost:3000) 