### PR TITLE
chore: remove `/get_image`

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7139,17 +7139,6 @@ async def claim_onboarding_link(data: InvitationClaim):
     return user_obj
 
 
-@app.get("/get_image", include_in_schema=False)
-def get_image():
-    """Get logo to show on UI"""
-    current_dir = os.path.dirname(os.path.abspath(__file__))  # proxy/
-    menlo_logo = os.path.join(current_dir, "menlo.svg")
-    
-    verbose_proxy_logger.debug("Reading Menlo logo from path: %s", menlo_logo)
-    
-    return FileResponse(menlo_logo, media_type="image/svg+xml")
-
-
 #### INVITATION MANAGEMENT ####
 
 

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -30,7 +30,7 @@ const Navbar: React.FC<NavbarProps> = ({
   setProxySettings,
   accessToken,
 }) => {
-  const imageUrl = `${process.env.API_URL}/get_image`;
+  const imageUrl = "/ui/assets/logos/menlo.svg";
   const [logoutUrl, setLogoutUrl] = useState("");
 
   useEffect(() => {
@@ -81,7 +81,7 @@ const Navbar: React.FC<NavbarProps> = ({
             <Link href="/" className="flex items-center">
               <img
                 src={imageUrl}
-                alt="LiteLLM Brand"
+                alt="Menlo Platform"
                 className="h-8 w-auto"
               />
             </Link>


### PR DESCRIPTION
`/get_image` is only used by FE to fetch banner logo. Change this to static asset in FE instead.
