### PR TITLE
CI: Add git commit to BE Docker image

### DIFF
--- a/.github/workflows/be-prod.yml
+++ b/.github/workflows/be-prod.yml
@@ -24,3 +24,5 @@ jobs:
       context: .
       registry-url: registry.menlo.ai
       tags: registry.menlo.ai/library/litellm-be:${{ needs.get-tag.outputs.new_version }}
+      build-args: |
+        GIT_COMMIT=${{ github.sha }}

--- a/.github/workflows/be-stag.yml
+++ b/.github/workflows/be-stag.yml
@@ -20,3 +20,5 @@ jobs:
       context: .
       registry-url: registry.menlo.ai
       tags: registry.menlo.ai/library/litellm-be:stag-${{ github.sha }}
+      build-args: |
+        GIT_COMMIT=${{ github.sha }}


### PR DESCRIPTION
Add git commit env var to BE Docker image. This will be used for S3 loggings.

To test: check if S3 loggings has git commit as folder suffix